### PR TITLE
AnchoredModalForm

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ class Parent extends React.Component {
 }
 ```
 
+An **AnchoredModalForm** (`import ModalForm from 'modal-form/anchored'`) can be attached where a normal form isn't allowed, for example within SVG elements or other forms. The form itself will be rendered in a new `React.render()` context.
+
 ### Props
 
 | Prop | Type | Description |

--- a/anchored.js
+++ b/anchored.js
@@ -1,0 +1,70 @@
+;(function() {
+  var React;
+  var ModalForm;
+  if (typeof require !== 'undefined') {
+    React = require('react');
+    ModalForm = require('./index');
+  } else if (typeof window !== 'undefined') {
+    React = window.React;
+    ModalForm = ZUIModalForm;
+  }
+
+  var AnchoredModalForm = React.createClass({
+    displayName: 'AnchoredModalForm',
+
+    getInitialState: function() {
+      return {
+        root: null
+      }
+    },
+
+    componentDidMount: function() {
+      var root = document.createElement('div');
+      root.classList.add('anchored-modal-form-root');
+      document.body.appendChild(root);
+
+      this.setState({
+        root: root
+      }, function() {
+        this.renderModal();
+      }.bind(this));
+    },
+
+    componentWillUnmount: function() {
+      if (this.state.root !== null) {
+        React.unmountComponentAtNode(this.state.root);
+        this.state.root.parentElement.removeChild(this.state.root);
+        this.setState({
+          root: null
+        });
+      }
+    },
+
+    render: function() {
+      return React.createElement('noscript', {
+        className: 'modal-form-anchor'
+      });
+    },
+
+    renderModal: function(shouldReposition) {
+      var parent = this.getDOMNode().parentElement;
+      var extendedProps = Object.assign({}, this.props, {
+        anchor: parent
+      });
+      var form = React.render(React.createElement(ModalForm, extendedProps), this.state.root);
+      if (shouldReposition) {
+        form.reposition();
+      }
+    },
+
+    componentDidUpdate: function() {
+      this.renderModal(true);
+    }
+  });
+
+  if (typeof module !== 'undefined') {
+    module.exports = AnchoredModalForm;
+  } else if (typeof window !== 'undefined') {
+    window.ZUIAnchoredModalForm = AnchoredModalForm;
+  }
+}());

--- a/index.js
+++ b/index.js
@@ -30,7 +30,9 @@
     propTypes: {
       anchor: React.PropTypes.instanceOf(Element),
       required: React.PropTypes.bool,
-      side: React.PropTypes.oneOf(['bottom']), // TODO: Enable top, left, right, center.
+      side: React.PropTypes.oneOf([
+        'bottom'
+      ]), // TODO: Enable top, left, right, center.
       underlayStyle: React.PropTypes.object,
       pointerStyle: React.PropTypes.object,
       onSubmit: React.PropTypes.func,

--- a/package.json
+++ b/package.json
@@ -9,6 +9,6 @@
   },
   "scripts": {
     "sauce": "zuul ./test.js",
-    "test": "zuul --local 7357 ./test.js"
+    "test": "zuul --local 7357 ./test/index.js"
   }
 }

--- a/package.json
+++ b/package.json
@@ -2,13 +2,14 @@
   "name": "modal-form",
   "version": "0.0.1",
   "devDependencies": {
+    "object-assign": "~4.0.1",
     "react": "~0.13.3",
     "simulant": "~0.1.5",
     "tape": "~4.0.2",
     "zuul": "~3.2.0"
   },
   "scripts": {
-    "sauce": "zuul ./test.js",
+    "sauce": "zuul ./test/index.js",
     "test": "zuul --local 7357 ./test/index.js"
   }
 }

--- a/test/anchored.js
+++ b/test/anchored.js
@@ -1,0 +1,42 @@
+var test = require('tape');
+var React = require('react/addons');
+// var TestUtils = React.addons.TestUtils;
+var AnchoredModalForm = require('../anchored');
+// var simulant = window.simulant = require('simulant');
+
+test('AnchoredModalForm', function(t) {
+  t.test('is exported', function(t) {
+    t.equal(typeof AnchoredModalForm, 'function', 'Exported the constructor');
+    t.end();
+  });
+
+  t.test('can be created', function(t) {
+    var instance = React.createElement(AnchoredModalForm);
+    t.ok(instance, 'Instance created');
+    t.end();
+  });
+
+  test('An instance', function(t) {
+    var ANCHORED_CONTENT_ID = 'anchored-content';
+
+    var root = document.createElement('div');
+    document.body.appendChild(root);
+
+    // Note, the anchored content is a <p>,
+    // which cannot be the decendant of the container <p>.
+
+    var content = React.createElement('p', {
+      id: ANCHORED_CONTENT_ID
+    });
+
+    var formAnchor = React.createElement(AnchoredModalForm, null, content);
+
+    var container = React.createElement('p', null, formAnchor);
+
+    React.render(container, root);
+
+    t.ok(document.querySelector('#' + ANCHORED_CONTENT_ID), 'Anchored content has been rendered');
+    t.notOk(root.querySelector('#' + ANCHORED_CONTENT_ID), 'Anchored content is not in the original rendering root');
+    t.end()
+  });
+});

--- a/test/anchored.js
+++ b/test/anchored.js
@@ -16,7 +16,7 @@ test('AnchoredModalForm', function(t) {
     t.end();
   });
 
-  test('An instance', function(t) {
+  t.test('An instance', function(t) {
     var ANCHORED_CONTENT_ID = 'anchored-content';
 
     var root = document.createElement('div');
@@ -37,6 +37,7 @@ test('AnchoredModalForm', function(t) {
 
     t.ok(document.querySelector('#' + ANCHORED_CONTENT_ID), 'Anchored content has been rendered');
     t.notOk(root.querySelector('#' + ANCHORED_CONTENT_ID), 'Anchored content is not in the original rendering root');
-    t.end()
+    t.end();
   });
+  t.end();
 });

--- a/test/index.js
+++ b/test/index.js
@@ -1,2 +1,5 @@
+if (Object.assign === undefined) {
+  Object.assign = require('object-assign');
+}
 require('./modal-form');
 require('./anchored');

--- a/test/index.js
+++ b/test/index.js
@@ -1,0 +1,2 @@
+require('./modal-form');
+require('./anchored');

--- a/test/modal-form.js
+++ b/test/modal-form.js
@@ -1,13 +1,13 @@
 var test = require('tape');
 var React = require('react/addons');
 var TestUtils = React.addons.TestUtils;
-var ModalForm = require('./index');
+var ModalForm = require('../index');
 var simulant = window.simulant = require('simulant');
 
 test('ModalForm', function(t) {
   t.test('is exported', function(t) {
     t.plan(1);
-    t.notEqual(ModalForm, undefined, 'Exported');
+    t.equal(typeof ModalForm, 'function', 'Exported the constructor');
   });
 
   t.test('can be created', function(t) {


### PR DESCRIPTION
This is an externally rendered version of the ModalForm component. Rendering externally means it can be instantiated it as a child of an SVG shape (or within another form or a paragraph or wherever forms normally couldn't go).

Used for drawing task details in the classifier of the ~~misnamed "break-apart-survey"~~ "classifier-refactor" branch of Panoptes-Front-End.