### PR TITLE
Watch history events state

### DIFF
--- a/.zuul.yml
+++ b/.zuul.yml
@@ -1,10 +1,10 @@
 ui: mocha-bdd
 browsers:
   - name: chrome
-    version: latest
+    version: -1..latest
   - name: firefox
-    version: latest
+    version: -1..latest
   - name: ie
-    version: latest
+    version: -1..latest
   - name: iphone
-    version: latest
+    version: -1..latest

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Just a form wrapped in a screen-covering underlay You'll probably never use this
 
 * `underlayStyle`: Overrides the style of the underlay.
 
-* `persistAcrossLocations`: Don't call the `onCancel` handler when the location hash changes. Defaults to `false`.
+* `persistAcrossLocations`: Don't call the `onCancel` handler when the location changes. Defaults to `false`. `hashchange` is supported by default, but the **[history-events](https://www.npmjs.com/package/history-events)** module is required if you want to track `history.pushState`.
 
 * `loose`: Render the form underlay directly into its parent element? Defaults to `false`, which renders it into a container the body above everything else.
 

--- a/base.js
+++ b/base.js
@@ -29,6 +29,7 @@
     React.Component.apply(this, arguments);
     this.handleGlobalKeyDown = this.handleGlobalKeyDown.bind(this);
     this.handleGlobalNavigation = this.handleGlobalNavigation.bind(this);
+    this.lastKnownLocation = location.href;
   }
 
   ModalFormBase.propTypes = {
@@ -50,14 +51,18 @@
   };
 
   ModalFormBase.prototype = Object.assign(Object.create(React.Component.prototype), {
+    lastKnownLocation: '',
+
     componentDidMount: function() {
       addEventListener('keydown', this.handleGlobalKeyDown);
       addEventListener('hashchange', this.handleGlobalNavigation);
+      addEventListener('changestate', this.handleGlobalNavigation); // If the `history-events` module is loaded.
     },
 
     componentWillUnmount: function() {
       removeEventListener('keydown', this.handleGlobalKeyDown);
       removeEventListener('hashchange', this.handleGlobalNavigation);
+      removeEventListener('changestate', this.handleGlobalNavigation);
     },
 
     handleGlobalKeyDown: function (event) {
@@ -67,8 +72,11 @@
     },
 
     handleGlobalNavigation: function() {
-      if (!this.props.required && !this.props.persistAcrossLocations) {
-        this.props.onCancel.apply(null, arguments);
+      if (location.href !== this.lastKnownLocation) {
+        this.lastKnownLocation = location.href;
+        if (!this.props.required && !this.props.persistAcrossLocations) {
+          this.props.onCancel.apply(null, arguments);
+        }
       }
     },
 

--- a/example.html
+++ b/example.html
@@ -127,11 +127,11 @@
 
         showAlert() {
           ZUIModalDialog.alert(<p>Check the console for the resulting value. <button type="submit" autoFocus>OK</button></p>)
-            .then(function() {
+            .then(() => {
               console.info('Alert resolved with', ...arguments);
             })
-            .catch(function() {
-              console.info('Alert rejected with', ...arguments);
+            .catch(() => {
+              console.warn('Alert rejected with', ...arguments);
             });
         }
       });

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "devDependencies": {
     "es6-promise": "~3.0.2",
+    "history-events": "~1.0.4",
     "mocha": "~2.3.2",
     "object-assign": "~4.0.1",
     "phantomjs": "~1.9.18",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "react": "~0.13.3",
     "simulant": "~0.1.5",
     "sinon": "~1.16.1",
-    "zuul": "~3.2.0"
+    "zuul": "~3.5.0"
   },
   "scripts": {
     "test": "zuul --phantom -- ./test/*.js",

--- a/test/base.js
+++ b/test/base.js
@@ -1,4 +1,5 @@
 Object.assign || (Object.assign = require('object-assign'));
+require('history-events');
 var React = require('react');
 var ModalFormBase = require('../base');
 var assert = require('assert');
@@ -56,6 +57,16 @@ describe('ModalFormBase', function() {
       location.hash = Math.random().toString(36).split('.')[1];
       setTimeout(function() {
         assert(cancelHandler.calledOnce);
+        cancelHandler.reset();
+        done();
+      }, 500);
+    });
+
+    it('calls onCancel when the history state changes', function(done) {
+      history.pushState({}, '', Math.random().toString(36).split('.')[1]);
+      setTimeout(function() {
+        assert(cancelHandler.calledOnce);
+        history.back();
         cancelHandler.reset();
         done();
       });


### PR DESCRIPTION
Modals will now watch the `statechange` event (part of the history-events module) and cancel when appropriate.

I don't want to make history-events explicitly required since it messes with some built-in objects. It is absurd that `history.pushState` doesn't fire an event natively.

This also tests each browser's two most recent versions on Sauce Labs.