### PR TITLE
Remove hook into history-events, make location change event customizable

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Just a form wrapped in a screen-covering underlay You'll probably never use this
 
 * `underlayStyle`: Overrides the style of the underlay.
 
-* `persistAcrossLocations`: Don't call the `onCancel` handler when the location changes. Defaults to `false`. `hashchange` is supported by default, but the **[history-events](https://www.npmjs.com/package/history-events)** module is required if you want to track `history.pushState`.
+* `persistAcrossLocations`: Don't call the `onCancel` handler when the location changes. Defaults to `false`. `hashchange` is supported by default. To track other location-changing events, trigger them manually and set `BaseModalForm.locationChangeEvent` to the event name (defaults to `"locationchange"`) before mounting any modal forms.
 
 * `loose`: Render the form underlay directly into its parent element? Defaults to `false`, which renders it into a container the body above everything else.
 

--- a/base.js
+++ b/base.js
@@ -32,6 +32,8 @@
     this.lastKnownLocation = location.href;
   }
 
+  ModalFormBase.locationChangeEvent = 'locationchange';
+
   ModalFormBase.propTypes = {
     required: React.PropTypes.bool,
     underlayStyle: React.PropTypes.object,
@@ -56,13 +58,13 @@
     componentDidMount: function() {
       addEventListener('keydown', this.handleGlobalKeyDown);
       addEventListener('hashchange', this.handleGlobalNavigation);
-      addEventListener('changestate', this.handleGlobalNavigation); // If the `history-events` module is loaded.
+      addEventListener(ModalFormBase.locationChangeEvent, this.handleGlobalNavigation);
     },
 
     componentWillUnmount: function() {
       removeEventListener('keydown', this.handleGlobalKeyDown);
       removeEventListener('hashchange', this.handleGlobalNavigation);
-      removeEventListener('changestate', this.handleGlobalNavigation);
+      removeEventListener(ModalFormBase.locationChangeEvent, this.handleGlobalNavigation);
     },
 
     handleGlobalKeyDown: function (event) {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "version": "1.0.1",
   "devDependencies": {
     "es6-promise": "~3.0.2",
-    "history-events": "~1.0.4",
     "mocha": "~2.3.2",
     "object-assign": "~4.0.1",
     "phantomjs": "~1.9.18",

--- a/test/base.js
+++ b/test/base.js
@@ -1,5 +1,4 @@
 Object.assign || (Object.assign = require('object-assign'));
-require('history-events');
 var React = require('react');
 var ModalFormBase = require('../base');
 var assert = require('assert');
@@ -64,6 +63,7 @@ describe('ModalFormBase', function() {
 
     it('calls onCancel when the history state changes', function(done) {
       history.pushState({}, '', Math.random().toString(36).split('.')[1]);
+      simulant.fire(window, 'locationchange');
       setTimeout(function() {
         assert(cancelHandler.calledOnce);
         history.back();


### PR DESCRIPTION
Location change events now handled in zooniverse/Panoptes-Front-End#1582