### PR TITLE
Fix ie11 positioning

### DIFF
--- a/anchor.js
+++ b/anchor.js
@@ -22,7 +22,7 @@
 
     componentWillUnmount: function() {
       React.unmountComponentAtNode(this.root);
-      this.root.parentElement.removeChild(this.root);
+      this.root.parentNode.removeChild(this.root);
       this.root = null;
       this.instance = null;
     },

--- a/base.js
+++ b/base.js
@@ -53,8 +53,6 @@
   };
 
   ModalFormBase.prototype = Object.assign(Object.create(React.Component.prototype), {
-    lastKnownLocation: '',
-
     componentDidMount: function() {
       addEventListener('keydown', this.handleGlobalKeyDown);
       addEventListener('hashchange', this.handleGlobalNavigation);
@@ -74,11 +72,8 @@
     },
 
     handleGlobalNavigation: function() {
-      if (location.href !== this.lastKnownLocation) {
-        this.lastKnownLocation = location.href;
-        if (!this.props.required && !this.props.persistAcrossLocations) {
-          this.props.onCancel.apply(null, arguments);
-        }
+      if (!this.props.required && !this.props.persistAcrossLocations) {
+        this.props.onCancel.apply(null, arguments);
       }
     },
 

--- a/dialog.js
+++ b/dialog.js
@@ -46,7 +46,7 @@
 
         promise.catch(Function.prototype).then(function() {
           React.unmountComponentAtNode(container);
-          container.parentElement.removeChild(container);
+          container.parentNode.removeChild(container);
         });
 
         return promise;

--- a/example.html
+++ b/example.html
@@ -110,6 +110,23 @@
               </ZUITriggeredModalForm>
             </p>
 
+            <p>
+              In an SVG:{' '}
+              <svg width="1.5em" height="1.5em" viewBox="0 0 100 100" style={{
+                verticalAlign: 'middle'
+              }}>
+                <ZUITriggeredModalForm side="right" triggerTag="g" trigger={
+                  <circle cx="50" cy="50" r="45" fill="red" stroke="none" />
+                } triggerProps={{
+                  style: {
+                    cursor: 'pointer'
+                  }
+                }}>
+                  <p>No problem!</p>
+                </ZUITriggeredModalForm>
+              </svg>
+            </p>
+
             <hr />
 
             <p>

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "modal-form",
   "version": "1.1.0",
   "devDependencies": {
+    "custom-event": "~1.0.0",
     "es6-promise": "~3.0.2",
     "mocha": "~2.3.2",
     "object-assign": "~4.0.1",

--- a/sticky.js
+++ b/sticky.js
@@ -68,7 +68,7 @@
         height: innerHeight
       };
 
-      var anchor = React.findDOMNode(this).parentElement;
+      var anchor = React.findDOMNode(this).parentNode;
       var anchorRect = this.getRectWithMargin(anchor);
 
       var form = React.findDOMNode(this.refs.form);

--- a/test/anchor.js
+++ b/test/anchor.js
@@ -9,58 +9,73 @@ describe('ModalFormAnchor', function() {
     assert.equal(typeof ModalFormAnchor, 'function');
   });
 
-  describe('instance', function() {
-    var id;
-    var root;
-    var instance;
+  function runInstanceTests(ancestorTags) {
+    return describe('instance with ancestry ' + ancestorTags.join('/'), function() {
+      var id;
+      var ancestors;
+      var instance;
 
-    beforeEach(function() {
-      id = Math.random().toString().split('.')[1];
+      beforeEach(function() {
+        id = Math.random().toString().split('.')[1];
 
-      root = document.createElement('div');
-      document.body.appendChild(root);
+        ancestors = ancestorTags.map(function(ancestorTag) {
+          return document.createElement(ancestorTag);
+        });
+        ancestors.reduce(function(parent, element) {
+          parent.appendChild(element);
+          return element;
+        }, document.body);
 
-      var contentDiv = React.createElement('div', {
-        id: id
-      });
-      instance = React.render(React.createElement(ModalFormAnchor, null, contentDiv), root);
-    });
-
-    it('is instantiated', function() {
-      assert.ok(instance);
-    });
-
-    it('drops an anchor', function() {
-      assert.equal(React.findDOMNode(instance).tagName, 'NOSCRIPT');
-    });
-
-    it('is renders its root in the body', function() {
-      assert.equal(instance.root.parentElement, document.body);
-    });
-
-    describe('content', function() {
-      it('renders into the document', function() {
-        assert.ok(document.getElementById(id));
+        var contentDiv = React.createElement('div', {
+          id: id
+        });
+        instance = React.render(React.createElement(ModalFormAnchor, null, contentDiv), ancestors[ancestors.length - 1]);
       });
 
-      it('renders outside of itself', function() {
-        var descendants = Array.prototype.slice.call(React.findDOMNode(instance).querySelectorAll('*'));
-        var contentDiv = document.getElementById(id);
-        assert.equal(descendants.indexOf(contentDiv), -1);
+      it('is instantiated', function() {
+        assert.ok(instance);
       });
 
-      it('updates in response to change', function() {
-        var renderInstance = sinon.spy(instance, 'renderInstance');
-        instance.forceUpdate();
-        assert(renderInstance.calledOnce);
+      it('drops an anchor', function() {
+        assert.equal(React.findDOMNode(instance).tagName, 'NOSCRIPT');
+      });
+
+      it('renders its root in the body', function() {
+        assert.equal(instance.root.parentNode, document.body);
+      });
+
+      describe('content', function() {
+        it('renders into the document', function() {
+          assert.ok(document.getElementById(id));
+        });
+
+        it('renders outside of itself', function() {
+          var descendants = Array.prototype.slice.call(React.findDOMNode(instance).querySelectorAll('*'));
+          var contentDiv = document.getElementById(id);
+          assert.equal(descendants.indexOf(contentDiv), -1);
+        });
+
+        it('updates in response to change', function() {
+          var renderInstance = sinon.spy(instance, 'renderInstance');
+          instance.forceUpdate();
+          assert(renderInstance.calledOnce);
+        });
+      });
+
+      afterEach(function() {
+        React.unmountComponentAtNode(ancestors[ancestors.length - 1]);
+        ancestors.forEach(function(element) {
+          element.parentNode.removeChild(element);
+        });
+        id = null;
+        ancestors = null;
+        instance = null;
       });
     });
+  }
 
-    afterEach(function() {
-      React.unmountComponentAtNode(root);
-      root.parentElement.removeChild(root);
-      root = null;
-      instance = null;
-    });
-  })
+  [
+    ['div'],
+    ['svg', 'rect']
+  ].map(runInstanceTests);
 });

--- a/test/base.js
+++ b/test/base.js
@@ -4,6 +4,7 @@ var ModalFormBase = require('../base');
 var assert = require('assert');
 var sinon = require('sinon');
 var simulant = require('simulant');
+var CustomEvent = require('custom-event');
 
 describe('ModalFormBase', function() {
   it('exports', function() {
@@ -52,24 +53,16 @@ describe('ModalFormBase', function() {
       cancelHandler.reset();
     });
 
-    it('calls onCancel when the hash changes', function(done) {
-      location.hash = Math.random().toString(36).split('.')[1];
-      setTimeout(function() {
-        assert(cancelHandler.calledOnce);
-        cancelHandler.reset();
-        done();
-      }, 500);
+    it('calls onCancel when the hash changes', function() {
+      dispatchEvent(new CustomEvent('hashchange'));
+      assert(cancelHandler.calledOnce);
+      cancelHandler.reset();
     });
 
-    it('calls onCancel when the history state changes', function(done) {
-      history.pushState({}, '', Math.random().toString(36).split('.')[1]);
-      simulant.fire(window, 'locationchange');
-      setTimeout(function() {
-        assert(cancelHandler.calledOnce);
-        history.back();
-        cancelHandler.reset();
-        done();
-      });
+    it('calls onCancel when the history state changes', function() {
+      dispatchEvent(new CustomEvent('locationchange'));
+      assert(cancelHandler.calledOnce);
+      cancelHandler.reset();
     });
 
     afterEach(function() {

--- a/test/base.js
+++ b/test/base.js
@@ -74,7 +74,7 @@ describe('ModalFormBase', function() {
 
     afterEach(function() {
       React.unmountComponentAtNode(root);
-      root.parentElement.removeChild(root);
+      root.parentNode.removeChild(root);
       root = null;
       instance = null;
       submitHandler = null;

--- a/test/sticky.js
+++ b/test/sticky.js
@@ -89,7 +89,7 @@ describe('StickyModalForm', function() {
 
     afterEach(function() {
       React.unmountComponentAtNode(root);
-      root.parentElement.removeChild(root);
+      root.parentNode.removeChild(root);
       root = null;
     });
   });

--- a/test/triggered.js
+++ b/test/triggered.js
@@ -57,7 +57,7 @@ describe('TriggeredModalForm', function() {
 
     afterEach(function() {
       React.unmountComponentAtNode(root);
-      root.parentElement.removeChild(root);
+      root.parentNode.removeChild(root);
       root = null;
       instance = null;
     });


### PR DESCRIPTION
Fixes positioning against SVG elements in IE11 by using `parentNode` instead of `parentElement`. I changed this everywhere, because why use `parentElement` at all? Closes #8.

Also simplifies location handling (it's not this module's responsibility to track actual location changes, just to respond to those events) and fixes location-change related tests in IE by using a `CustomEvent` implementation instead of whatever simulant does.