### PR TITLE
Allow scrolling

### DIFF
--- a/base.js
+++ b/base.js
@@ -16,7 +16,7 @@
   var UNDERLAY_STYLE = {
     bottom: 0,
     left: 0,
-    position: 'fixed',
+    position: 'absolute',
     right: 0,
     top: 0
   };
@@ -30,6 +30,10 @@
     this.handleGlobalKeyDown = this.handleGlobalKeyDown.bind(this);
     this.handleGlobalNavigation = this.handleGlobalNavigation.bind(this);
     this.lastKnownLocation = location.href;
+    this.state = {
+      underlayScrollWidth: 0,
+      underlayScrollHeight: 0
+    };
   }
 
   ModalFormBase.locationChangeEvent = 'locationchange';
@@ -57,6 +61,7 @@
       addEventListener('keydown', this.handleGlobalKeyDown);
       addEventListener('hashchange', this.handleGlobalNavigation);
       addEventListener(ModalFormBase.locationChangeEvent, this.handleGlobalNavigation);
+      this.syncUnderlaySize();
     },
 
     componentWillUnmount: function() {
@@ -96,17 +101,37 @@
     },
 
     renderLoose: function() {
+      var underlaySize = {
+        width: Math.max(this.state.underlayScrollWidth, document.documentElement.offsetWidth, innerWidth) + 'px',
+        height: Math.max(this.state.underlayScrollHeight, document.documentElement.offsetHeight, innerHeight) + 'px'
+      };
       return React.createElement.apply(React, ['div', {
         ref: 'underlay',
         className: ('modal-form-underlay ' + (this.props.className || '')).trim(),
-        style: Object.assign({}, UNDERLAY_STYLE, this.props.underlayStyle),
+        style: Object.assign({}, UNDERLAY_STYLE, underlaySize, this.props.underlayStyle),
         onClick: this.handleUnderlayClick.bind(this)
       }].concat(this.getUnderlayChildren()));
     },
 
     renderWithAnchor: function() {
-      var looseRenderResult = ModalFormBase.prototype.renderLoose.apply(this, arguments);
+      var looseRenderResult = this.renderLoose.apply(this, arguments);
       return React.createElement(ModalFormAnchor, null, looseRenderResult);
+    },
+
+    componentDidUpdate: function() {
+      this.syncUnderlaySize();
+    },
+
+    syncUnderlaySize: function() {
+      var underlay = React.findDOMNode(this.refs.underlay);
+      var widthChanged = underlay.scrollWidth !== this.state.underlayScrollWidth;
+      var heightChanged = underlay.scrollHeight !== this.state.underlayScrollHeight;
+      if (widthChanged || heightChanged) {
+        this.setState({
+          underlayScrollWidth: underlay.scrollWidth,
+          underlayScrollHeight: underlay.scrollHeight
+        });
+      }
     },
 
     handleFormSubmit: function(event) {

--- a/sticky.js
+++ b/sticky.js
@@ -76,16 +76,18 @@
       form.style.top = '';
       var formRect = this.getRectWithMargin(form);
       var formPosition = this.getPosition[props.side].call(this, formRect, anchorRect, viewport);
-      form.style.left = formPosition.left + 'px';
-      form.style.top = formPosition.top + 'px';
+      form.style.left = pageXOffset + formPosition.left + 'px';
+      form.style.top = pageYOffset + formPosition.top + 'px';
 
       var pointer = React.findDOMNode(this.refs.pointer);
       pointer.style.left = '';
       pointer.style.top = '';
       var pointerRect = this.getRectWithMargin(pointer);
       var pointerPosition = this.getPosition[props.side].call(this, pointerRect, anchorRect, viewport);
-      pointer.style.left = pointerPosition.left + 'px';
-      pointer.style.top = pointerPosition.top + 'px';
+      pointer.style.left = pageXOffset + pointerPosition.left + 'px';
+      pointer.style.top = pageYOffset + pointerPosition.top + 'px';
+
+      this.syncUnderlaySize();
     },
 
     getRectWithMargin: function(domNode) {
@@ -104,15 +106,13 @@
 
     getHorizontallyCenteredLeft: function(movableRect, anchorRect, viewport) {
       var left = anchorRect.left - ((movableRect.width - anchorRect.width) / 2);
-      left = Math.max(left, 0);
-      left = Math.min(left, viewport.width - movableRect.width);
+      left = Math.max(left, -1 * pageXOffset);
       return left;
     },
 
     getVerticalCenteredTop: function(movableRect, anchorRect, viewport) {
       var top = anchorRect.top - ((movableRect.height - anchorRect.height) / 2);
-      top = Math.max(top, 0);
-      top = Math.min(top, viewport.height - movableRect.height)
+      top = Math.max(top, -1 * pageYOffset);
       return top;
     },
 


### PR DESCRIPTION
Allows scrolling with a modal open by positioning the underlay `absolute`ly instead of `fixed` and adding the scroll offset to the form.

The underlay's dimensions are now determined by its contents, the document's contents, or the viewport; whichever's largest.

Closes #9, and then zooniverse/Panoptes-Front-End#1631 when it's updated to use this.