### PR TITLE
Positioning improvements

### DIFF
--- a/base.js
+++ b/base.js
@@ -29,7 +29,6 @@
     React.Component.apply(this, arguments);
     this.handleGlobalKeyDown = this.handleGlobalKeyDown.bind(this);
     this.handleGlobalNavigation = this.handleGlobalNavigation.bind(this);
-    this.lastKnownLocation = location.href;
     this.state = {
       underlayScrollWidth: 0,
       underlayScrollHeight: 0

--- a/base.js
+++ b/base.js
@@ -14,10 +14,8 @@
   var ESC_KEY = 27;
 
   var UNDERLAY_STYLE = {
-    bottom: 0,
     left: 0,
     position: 'absolute',
-    right: 0,
     top: 0
   };
 
@@ -27,11 +25,12 @@
 
   function ModalFormBase() {
     React.Component.apply(this, arguments);
+    this.reposition = this.reposition.bind(this);
     this.handleGlobalKeyDown = this.handleGlobalKeyDown.bind(this);
     this.handleGlobalNavigation = this.handleGlobalNavigation.bind(this);
     this.state = {
-      underlayScrollWidth: 0,
-      underlayScrollHeight: 0
+      underlayWidth: 0,
+      underlayHeight: 0
     };
   }
 
@@ -57,13 +56,17 @@
 
   ModalFormBase.prototype = Object.assign(Object.create(React.Component.prototype), {
     componentDidMount: function() {
+      addEventListener('scroll', this.reposition);
+      addEventListener('resize', this.reposition);
       addEventListener('keydown', this.handleGlobalKeyDown);
       addEventListener('hashchange', this.handleGlobalNavigation);
       addEventListener(ModalFormBase.locationChangeEvent, this.handleGlobalNavigation);
-      this.syncUnderlaySize();
+      this.reposition();
     },
 
     componentWillUnmount: function() {
+      removeEventListener('scroll', this.reposition);
+      removeEventListener('resize', this.reposition);
       removeEventListener('keydown', this.handleGlobalKeyDown);
       removeEventListener('hashchange', this.handleGlobalNavigation);
       removeEventListener(ModalFormBase.locationChangeEvent, this.handleGlobalNavigation);
@@ -101,8 +104,8 @@
 
     renderLoose: function() {
       var underlaySize = {
-        width: Math.max(this.state.underlayScrollWidth, document.documentElement.offsetWidth, innerWidth) + 'px',
-        height: Math.max(this.state.underlayScrollHeight, document.documentElement.offsetHeight, innerHeight) + 'px'
+        width: this.state.underlayWidth + 'px',
+        height: this.state.underlayHeight + 'px'
       };
       return React.createElement.apply(React, ['div', {
         ref: 'underlay',
@@ -118,17 +121,18 @@
     },
 
     componentDidUpdate: function() {
-      this.syncUnderlaySize();
+      this.reposition();
     },
 
-    syncUnderlaySize: function() {
-      var underlay = this.refs.underlay;
-      var widthChanged = underlay.scrollWidth !== this.state.underlayScrollWidth;
-      var heightChanged = underlay.scrollHeight !== this.state.underlayScrollHeight;
+    reposition: function() {
+      var totalWidth = Math.max(document.documentElement.offsetWidth, innerWidth);
+      var totalHeight = Math.max(document.documentElement.offsetHeight, innerHeight);
+      var widthChanged = totalWidth !== this.state.underlayWidth;
+      var heightChanged = totalHeight !== this.state.underlayHeight;
       if (widthChanged || heightChanged) {
         this.setState({
-          underlayScrollWidth: underlay.scrollWidth,
-          underlayScrollHeight: underlay.scrollHeight
+          underlayWidth: totalWidth,
+          underlayHeight: totalHeight
         });
       }
     },

--- a/dialog.js
+++ b/dialog.js
@@ -14,12 +14,6 @@
     ModalFormBase = window.ZUIModalFormBase;
   }
 
-  function mustBePercentString(props, propName, componentName) {
-    if (!/\d%/.test(props[propName])) {
-      return new Error('Must be a percent as a string, e.g. "50%".');
-    }
-  }
-
   var ModalDialog = React.createClass({
     statics: {
       alert: function(message, props) {
@@ -58,25 +52,25 @@
 
     propTypes: Object.assign({}, ModalFormBase.propTypes, {
       closeButton: React.PropTypes.bool,
-      left: mustBePercentString,
-      top: mustBePercentString
+      left: React.PropTypes.number,
+      top: React.PropTypes.number
     }),
 
     getDefaultProps: function() {
       return Object.assign({}, ModalFormBase.defaultProps, {
         closeButton: false,
-        left: '50%',
-        top: '40%'
+        left: 0.5,
+        top: 0.4
       });
     },
 
     render: function() {
       var positionStyle = {
-        left: this.props.left,
-        top: this.props.top,
+        left: (this.props.left * 100) + '%',
+        top: (this.props.top * 100) + '%',
         transform: 'translate(' + [
-          -1 * parseFloat(this.props.left) + '%',
-          -1 * parseFloat(this.props.top) + '%'
+          (this.props.left * -100) + '%',
+          (this.props.top * -100) + '%'
         ].join(',') + ')'
       };
 
@@ -84,7 +78,7 @@
         'role': 'dialog'
       }, this.props, {
         className: ('modal-dialog ' + (this.props.className || '')).trim(),
-        style: Object.assign(positionStyle, this.props.style)
+        style: Object.assign({}, positionStyle, this.props.style)
       });
 
       var closeButton;

--- a/dialog.js
+++ b/dialog.js
@@ -64,21 +64,28 @@
       });
     },
 
+    getInitialState: function() {
+      return {
+        scrollX: pageXOffset,
+        scrollY: pageYOffset,
+        dialogLeft: 0,
+        dialogTop: 0
+      };
+    },
+
     render: function() {
       var positionStyle = {
-        left: (this.props.left * 100) + '%',
-        top: (this.props.top * 100) + '%',
-        transform: 'translate(' + [
-          (this.props.left * -100) + '%',
-          (this.props.top * -100) + '%'
-        ].join(',') + ')'
+        left: this.state.dialogLeft,
+        top: this.state.dialogTop
       };
 
       var modalProps = Object.assign({
-        'role': 'dialog'
+        ref: 'modal',
+        role: 'dialog'
       }, this.props, {
         className: ('modal-dialog ' + (this.props.className || '')).trim(),
-        style: Object.assign({}, positionStyle, this.props.style)
+        style: Object.assign({}, positionStyle, this.props.style),
+        onReposition: this.reposition
       });
 
       var closeButton;
@@ -96,6 +103,22 @@
       }, closeButton);
 
       return React.createElement(ModalFormBase, modalProps, toolbar, this.props.children);
+    },
+
+    reposition: function() {
+      var form = this.refs.modal && this.refs.modal.refs.form;
+      if (form !== undefined) {
+        var horizontal = this.props.left * innerWidth;
+        var vertical = this.props.top * innerHeight;
+        var left = this.state.scrollX + Math.max(0, horizontal - (this.props.left * form.offsetWidth));
+        var top = this.state.scrollY + Math.max(0, vertical - (this.props.top * form.offsetHeight));
+        if (left !== this.state.dialogLeft || top !== this.state.dialogTop) {
+          this.setState({
+            dialogLeft: left,
+            dialogTop: top
+          });
+        }
+      }
     }
   });
 

--- a/example.html
+++ b/example.html
@@ -56,6 +56,10 @@
     <script src="./dialog.js"></script>
 
     <script type="text/babel">
+      function Spacer() {
+        return <p>·<br />·<br />·<br />·<br />·<br />·<br />·<br />·<br />·<br />·<br /></p>;
+      }
+
       const NormalDemo = React.createClass({
         getInitialState() {
           return {
@@ -67,7 +71,8 @@
           return <div style={{
             textAlign: 'center'
           }}>
-            <p>·<br />·<br />·<br /></p>
+            <Spacer />
+
             <p>
               Sticky:{' '}
               <span style={{
@@ -95,7 +100,9 @@
               </span>
             </p>
 
+            <Spacer />
             <hr />
+            <Spacer />
 
             <p>
               Triggered:{' '}
@@ -128,12 +135,16 @@
               </svg>
             </p>
 
+            <Spacer />
             <hr />
+            <Spacer />
 
             <p>
               Alert:{' '}
               <button type="button" onClick={this.showAlert}>Show it</button>
             </p>
+
+            <Spacer />
           </div>;
         },
 
@@ -144,7 +155,13 @@
         },
 
         showAlert() {
-          ZUIModalDialog.alert(<p>Check the console for the resulting value. <button type="submit" autoFocus>OK</button></p>)
+          ZUIModalDialog.alert(<div>
+            <Spacer />
+            <p>Check the console for the resulting value.</p>
+            <Spacer /><Spacer /><Spacer /><Spacer />
+            <p><button type="submit" autoFocus>OK</button></p>
+            <Spacer />
+          </div>)
             .then(() => {
               console.info('Alert resolved with', ...arguments);
             })

--- a/sticky.js
+++ b/sticky.js
@@ -22,7 +22,6 @@
 
   function StickyModalForm() {
     ModalFormBase.apply(this, arguments);
-    this.reposition = this.reposition.bind(this);
   }
 
   StickyModalForm.propTypes = Object.assign({}, ModalFormBase.propTypes, {
@@ -43,9 +42,6 @@
   StickyModalForm.prototype = Object.assign(Object.create(ModalFormBase.prototype), {
     componentDidMount: function() {
       ModalFormBase.prototype.componentDidMount.apply(this, arguments);
-      this.reposition();
-      addEventListener('scroll', this.reposition);
-      addEventListener('resize', this.reposition);
       // TODO: Figure out a way to add a global load event listener.
       Array.prototype.forEach.call(document.querySelectorAll(MEDIA_SELECTOR), function(media) {
         media.addEventListener('load', this.reposition)
@@ -54,14 +50,14 @@
 
     componentWillUnmount: function() {
       ModalFormBase.prototype.componentWillUnmount.apply(this, arguments);
-      removeEventListener('scroll', this.reposition);
-      removeEventListener('resize', this.reposition);
       Array.prototype.forEach.call(document.querySelectorAll(MEDIA_SELECTOR), function(media) {
         media.removeEventListener('load', this.reposition)
       }, this);
     },
 
     reposition: function(props) {
+      ModalFormBase.prototype.reposition.apply(this, arguments);
+
       if (props === undefined || props instanceof Event) {
         props = this.props;
       }
@@ -89,8 +85,6 @@
       var pointerPosition = this.getPosition[props.side].call(this, pointerRect, anchorRect, viewport);
       pointer.style.left = pageXOffset + pointerPosition.left + 'px';
       pointer.style.top = pageYOffset + pointerPosition.top + 'px';
-
-      this.syncUnderlaySize();
     },
 
     getRectWithMargin: function(domNode) {


### PR DESCRIPTION
Here're some changes to make dialogs a little less crappy (should improve project tutorials on mobile, specifically):

- The underlay is now sized to the largest of the viewport, the document content, or the modal's right/bottom bounds.

- The correct scroll position is maintained (previously the page would jump to the top between mounting and repositioning a modal when it contained an `autoFocus` child).

- Dialog position is now relative to viewport (instead of underlay) at mount-time, and if it's wider or taller than the viewport it locks to the viewport's left or top side.