### PR TITLE
Don't count vertical scrollbar in underlay dimensions

### DIFF
--- a/base.js
+++ b/base.js
@@ -152,7 +152,7 @@
       var formStyle = getComputedStyle(this.refs.form);
       var formRight = pageXOffset + formRect.right + parseFloat(formStyle.marginRight);
       var formBottom = pageYOffset + formRect.bottom + parseFloat(formStyle.marginBottom);
-      var totalWidth = Math.max(document.documentElement.offsetWidth, innerWidth, formRight);
+      var totalWidth = Math.max(document.documentElement.offsetWidth, formRight); // Skip `innerWidth` to avoid counting scrollbar.
       var totalHeight = Math.max(document.documentElement.offsetHeight, innerHeight, formBottom);
       if (totalWidth !== this.state.underlayWidth || totalHeight !== this.state.underlayHeight) {
         this.setState({

--- a/example.html
+++ b/example.html
@@ -45,10 +45,10 @@
   </head>
 
   <body>
-    <script src="https://fb.me/react-0.14.3.js"></script>
-    <script src="https://fb.me/react-dom-0.14.3.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/babel-core/5.8.23/browser-polyfill.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/babel-core/5.8.23/browser.js"></script>
+    <script src="./node_modules/react/dist/react.js"></script>
+    <script src="./node_modules/react-dom/dist/react-dom.js"></script>
+    <script src="./node_modules/babel-core/browser-polyfill.js"></script>
+    <script src="./node_modules/babel-core/browser.js"></script>
     <script src="./anchor.js"></script>
     <script src="./base.js"></script>
     <script src="./sticky.js"></script>

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "modal-form",
   "version": "2.3.0",
   "devDependencies": {
+    "babel-core": "~5.8.38",
     "custom-event": "~1.0.0",
     "es6-promise": "~3.0.2",
     "mocha": "~2.3.2",


### PR DESCRIPTION
Including the vertical scrollbar made the underlay too wide, which caused a horizontal scrollbar to appear.

Closes zooniverse/Panoptes-Front-End#2392.

Also, example.html now pulls dependencies from node_modules for offline dev.